### PR TITLE
fix remote reboot feature, it needs -f to work, ref: line 477 of /etc/init

### DIFF
--- a/folding_cd/initrd_dir/bin/benchmark.sh
+++ b/folding_cd/initrd_dir/bin/benchmark.sh
@@ -219,7 +219,7 @@ EOF
 cat << EOF > /bin/do_reboot.sh
 #!/bin/sh
 /bin/sleep 1
-/bin/reboot
+/bin/reboot -f
 EOF
 chmod 755 /bin/do_reboot.sh
 


### PR DESCRIPTION
Hi,
I found that reboot feature needs -f to work, you can refer to the line 477 of /etc/init, it will not work if it has no option or parameter, so I sent this pull request to fix it(though benchmark feature is not work in the new version), please merge this commit to fix, thanks!
Peter
