### PR TITLE
add parameter -p for mkdir to prevent error message if dir already exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ diskless/version.txt : initrd_dir/init
 
 ### folding.zip ###
 folding.zip: disk diskless/kernel diskless/initrd diskless/syslinux.cfg diskless/version.txt diskless/fold.txt initrd_dir/bin/syslinux folding/folding.vmx
-	mkdir folding
+	mkdir -p folding
 	mkdir -p $(MOUNT)
 	sudo losetup -o 32256 $(LOOPDEV) disk && \
 	mkdosfs -F 32 $(LOOPDEV) && \

--- a/initrd_dir/bin/benchmark.sh
+++ b/initrd_dir/bin/benchmark.sh
@@ -321,7 +321,7 @@ do
   echo "Loading processor $load_procs"
   echo "Loading processor $load_procs<BR>" >> /etc/header.html
   cat /etc/header.html /etc/results.html /etc/footer.html > /etc/folding/index.html
-  mkdir load_$load_procs
+  mkdir -p load_$load_procs
   if [ `expr $load_procs % 4` -eq 0 ]
   then
     cd /etc/fold.tinker

--- a/initrd_dir/init
+++ b/initrd_dir/init
@@ -657,7 +657,7 @@ grep -v backup index.backup > index.html
 while [ "$numprocs" -gt "0" ]
 do
   echo "Setting up instance $numprocs"
-  mkdir $numprocs
+  mkdir -p $numprocs
   cd $numprocs
   cat << EOF > client.cfg
 [settings]


### PR DESCRIPTION
Hi,
Sometimes I will create the directory manually because I want to add something addition but just local modify, like local patch or pre-downloaded client & core, use parameter -p like others can prevent the error message, I think it's useful, and I checked all the mkdir command in this project, most of then already use this parameter, so I made the remaining mkdir had this parameter, hope this commit can be merged into the master branch, thanks.
