### PR TITLE
Syslinux upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 /initrd_dir/etc/manifest
 /initrd_dir/lib/
 /initrd_dir/lib64/
+/initrd_dir/etc/folding/cgi-bin/ldlinux.c32
 /kernel_patch
 /kernel_firmware
 /linux-*

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MOUNT = /mnt
 KERNEL_VERSION = 3.15.8
 GLIBC_VERSION = 2.19
 BUSYBOX_VERSION = 1.22.1
-SYSLINUX_VERSION = 3.86
+SYSLINUX_VERSION = 6.02
 BZIP_VERSION = 1.0.6
 CDRKIT_VERSION = 1.1.7.1
 GCC_VERSION = 4.8.2
@@ -150,7 +150,7 @@ busybox-$(BUSYBOX_VERSION).tar.bz2 :
 	wget http://busybox.net/downloads/busybox-$(BUSYBOX_VERSION).tar.bz2
 
 syslinux-$(SYSLINUX_VERSION).tar.xz :
-	wget http://www.kernel.org/pub/linux/utils/boot/syslinux/3.xx/syslinux-$(SYSLINUX_VERSION).tar.xz
+	wget http://www.kernel.org/pub/linux/utils/boot/syslinux/syslinux-$(SYSLINUX_VERSION).tar.xz
 
 bzip2-$(BZIP_VERSION).tar.gz :
 	wget http://www.bzip.org/$(BZIP_VERSION)/bzip2-$(BZIP_VERSION).tar.gz
@@ -183,9 +183,10 @@ diskless/fold.txt : boot/fold.txt
 	cp boot/fold.txt diskless/fold.txt
 
 ### usb.zip ###
-usb.zip : diskless/kernel diskless/initrd diskless/syslinux.cfg diskless/version.txt diskless/fold.txt
+usb.zip : diskless/kernel diskless/initrd diskless/syslinux.cfg diskless/version.txt diskless/fold.txt boot/ldlinux.c32
 	mkdir -p diskless
 	cd diskless && \
+	cp ../boot/ldlinux.c32 ./ldlinux.c32 && \
 	zip -r ../usb.zip kernel initrd syslinux.cfg version.txt fold.txt
 
 diskless/syslinux.cfg : boot/isolinux.cfg
@@ -197,13 +198,13 @@ diskless/version.txt : initrd_dir/init
 	grep -m 1 VERSION= initrd_dir/init | sed s/VERSION=// > diskless/version.txt
 
 ### folding.zip ###
-folding.zip: disk diskless/kernel diskless/initrd diskless/syslinux.cfg diskless/version.txt diskless/fold.txt initrd_dir/bin/syslinux folding/folding.vmx
+folding.zip: disk diskless/kernel diskless/initrd diskless/syslinux.cfg diskless/version.txt diskless/fold.txt initrd_dir/bin/syslinux folding/folding.vmx boot/ldlinux.c32
 	mkdir -p folding
 	mkdir -p $(MOUNT)
 	sudo losetup -o 32256 $(LOOPDEV) disk && \
 	mkdosfs -F 32 $(LOOPDEV) && \
 	sudo mount $(LOOPDEV) $(MOUNT) && \
-	sudo cp diskless/kernel diskless/initrd diskless/syslinux.cfg diskless/version.txt diskless/fold.txt $(MOUNT) && \
+	sudo cp boot/ldlinux.c32 diskless/kernel diskless/initrd diskless/syslinux.cfg diskless/version.txt diskless/fold.txt $(MOUNT) && \
 	sudo umount $(MOUNT) && \
 	sudo initrd_dir/bin/syslinux $(LOOPDEV) && \
 	dosfsck -a $(LOOPDEV) ; \
@@ -223,7 +224,7 @@ part_gen: part_gen.c
 	gcc -o part_gen part_gen.c
 
 ### folding_cd.iso ###
-folding_cd.iso : boot/kernel boot/initrd boot/isolinux.bin boot/isolinux.cfg boot/fold.txt
+folding_cd.iso : boot/kernel boot/initrd boot/isolinux.bin boot/isolinux.cfg boot/fold.txt boot/ldlinux.c32
 	cp boot/isolinux.bin boot/isolin.bin && \
 	mkisofs -o folding_cd.iso -b isolin.bin -c boot.cat -no-emul-boot -boot-load-size 4 -input-charset utf-8 -boot-info-table boot && \
 	rm boot/isolin.bin
@@ -236,13 +237,20 @@ boot/fold.txt : patches/fold.txt
 	mkdir -p boot
 	cp patches/fold.txt boot
 
+boot/ldlinux.c32: syslinux_src
+	mkdir -p boot
+	cp syslinux-$(SYSLINUX_VERSION)/bios/com32/elflink/ldlinux/ldlinux.c32 boot
+
 #### initrd ####
-boot/initrd : initrd_dir/bin/isVMWare initrd_dir/bin/isVPC initrd_dir/bin/queueinfo initrd_dir/bin/busybox initrd_dir/bin/mbr.bin initrd_dir/bin/syslinux initrd_dir/etc/folding/cgi-bin/isolinux.bin initrd_dir/etc/folding/cgi-bin/kernel glibc_libs initrd_dir/init initrd_dir/bin/encode initrd_dir/bin/backup.sh initrd_dir/bin/check_hang.sh initrd_dir/bin/processor.awk initrd_dir/bin/average.awk initrd_dir/bin/bench.amber.awk initrd_dir/bin/bench.bonusgromacs.awk initrd_dir/bin/bench.gromacs33.awk initrd_dir/bin/bench.tinker.awk initrd_dir/bin/benchmark.sh initrd_dir/etc/folding/cgi-bin/index.cgi initrd_dir/etc/folding/cgi-bin/fold.txt initrd_dir/etc/folding/cgi-bin/reconf.cgi initrd_dir/etc/folding/cgi-bin/oneunit.cgi initrd_dir/lib64/libbz2.so.1 initrd_dir/lib64/libgcc_s.so.1 initrd_dir/lib64/libstdc++.so.6 initrd_dir/etc/folding/cgi-bin/fold.iso initrd_dir/bin/genisoimage kernel_firmware
+boot/initrd : initrd_dir/bin/isVMWare initrd_dir/bin/isVPC initrd_dir/bin/queueinfo initrd_dir/bin/busybox initrd_dir/bin/mbr.bin initrd_dir/bin/syslinux initrd_dir/etc/folding/cgi-bin/isolinux.bin initrd_dir/etc/folding/cgi-bin/kernel glibc_libs initrd_dir/init initrd_dir/bin/encode initrd_dir/bin/backup.sh initrd_dir/bin/check_hang.sh initrd_dir/bin/processor.awk initrd_dir/bin/average.awk initrd_dir/bin/bench.amber.awk initrd_dir/bin/bench.bonusgromacs.awk initrd_dir/bin/bench.gromacs33.awk initrd_dir/bin/bench.tinker.awk initrd_dir/bin/benchmark.sh initrd_dir/etc/folding/cgi-bin/index.cgi initrd_dir/etc/folding/cgi-bin/fold.txt initrd_dir/etc/folding/cgi-bin/reconf.cgi initrd_dir/etc/folding/cgi-bin/oneunit.cgi initrd_dir/lib64/libbz2.so.1 initrd_dir/lib64/libgcc_s.so.1 initrd_dir/lib64/libstdc++.so.6 initrd_dir/etc/folding/cgi-bin/fold.iso initrd_dir/bin/genisoimage kernel_firmware initrd_dir/etc/folding/cgi-bin/ldlinux.c32
 	mkdir -p initrd_dir/tmp
 	cd initrd_dir && \
 	chmod 1777 tmp && \
 	find . -name .svn -prune -o -print > etc/manifest && \
 	bin/busybox cpio -o -H newc < etc/manifest | gzip -9 > ../boot/initrd
+
+initrd_dir/etc/folding/cgi-bin/ldlinux.c32: boot/ldlinux.c32
+	cp boot/ldlinux.c32 initrd_dir/etc/folding/cgi-bin/ldlinux.c32
 
 initrd_dir/bin/queueinfo : glibc_libs queueinfo.c
 	mkdir -p initrd_dir/bin
@@ -267,49 +275,38 @@ initrd_dir/bin/genisoimage : glibc_libs cdrkit-$(CDRKIT_VERSION).tar.gz patches/
 	cp genisoimage/genisoimage ../../initrd_dir/bin/genisoimage
 
 #### isolinux, pxelinux, syslinux ####
-diskless/syslinux.exe : diskless/syslinux.com
+diskless/syslinux.exe : syslinux_src
 	mkdir -p diskless
-	$(MAKE) WINCC=i586-mingw32msvc-gcc WINAR=i586-mingw32msvc-ar WINRANLIB=i586-mingw32msvc-ranlib -C syslinux-$(SYSLINUX_VERSION)/win32 syslinux.exe && \
-	cp syslinux-$(SYSLINUX_VERSION)/win32/syslinux.exe diskless/syslinux.exe
+	cp syslinux-$(SYSLINUX_VERSION)/bios/win32/syslinux.exe diskless/syslinux.exe
 
-diskless/syslinux.com : initrd_dir/etc/folding/cgi-bin/isolinux.bin
+diskless/syslinux.com : syslinux_src
 	mkdir -p diskless
-	$(MAKE) -C syslinux-$(SYSLINUX_VERSION)/dos syslinux.com && \
-	cp syslinux-$(SYSLINUX_VERSION)/dos/syslinux.com diskless/syslinux.com
+	cp syslinux-$(SYSLINUX_VERSION)/bios/dos/syslinux.com diskless/syslinux.com
 
 initrd_dir/etc/folding/cgi-bin/isolinux.bin : boot/isolinux.bin
 	mkdir -p initrd_dir/etc/folding/cgi-bin
 	cp boot/isolinux.bin initrd_dir/etc/folding/cgi-bin/isolinux.bin
 
-boot/isolinux.bin : diskless/pxelinux.0
+boot/isolinux.bin : syslinux_src
 	mkdir -p boot
-	$(MAKE) -C syslinux-$(SYSLINUX_VERSION)/core isolinux.bin && \
-	cp syslinux-$(SYSLINUX_VERSION)/core/isolinux.bin boot/
+	cp syslinux-$(SYSLINUX_VERSION)/bios/core/isolinux.bin boot/
 
-diskless/pxelinux.0 : initrd_dir/bin/mbr.bin
+diskless/pxelinux.0 : syslinux_src
 	mkdir -p diskless
-	$(MAKE) -C syslinux-$(SYSLINUX_VERSION)/core pxelinux.0 && \
-	cp syslinux-$(SYSLINUX_VERSION)/core/pxelinux.0 diskless/
+	cp syslinux-$(SYSLINUX_VERSION)/bios/core/pxelinux.0 diskless/
 
-initrd_dir/bin/mbr.bin : initrd_dir/bin/syslinux
+initrd_dir/bin/mbr.bin : syslinux_src
 	mkdir -p initrd_dir/bin
-	$(MAKE) -C syslinux-$(SYSLINUX_VERSION)/mbr mbr_bin.c && \
-	$(MAKE) -C syslinux-$(SYSLINUX_VERSION)/mbr mbr.bin && \
-        cp syslinux-$(SYSLINUX_VERSION)/mbr/mbr.bin initrd_dir/bin/mbr.bin
+	cp syslinux-$(SYSLINUX_VERSION)/bios/mbr/mbr.bin initrd_dir/bin/mbr.bin
 
-initrd_dir/bin/syslinux : syslinux_src glibc_libs
+initrd_dir/bin/syslinux : syslinux_src
 	mkdir -p initrd_dir/bin
-	$(MAKE) -C syslinux-$(SYSLINUX_VERSION)/libinstaller ldlinux_bin.c && \
-	$(MAKE) -C syslinux-$(SYSLINUX_VERSION)/libinstaller bootsect_bin.c && \
-	$(MAKE) -C syslinux-$(SYSLINUX_VERSION)/linux syslinux.o && \
-	$(MAKE) -C syslinux-$(SYSLINUX_VERSION)/linux syslxmod.o && \
-	$(MAKE) -C syslinux-$(SYSLINUX_VERSION)/linux bootsect_bin.o && \
-	$(MAKE) -C syslinux-$(SYSLINUX_VERSION)/linux ldlinux_bin.o && \
-	gcc -s -L glibc -o initrd_dir/bin/syslinux syslinux-$(SYSLINUX_VERSION)/linux/syslinux.o syslinux-$(SYSLINUX_VERSION)/linux/syslxmod.o syslinux-$(SYSLINUX_VERSION)/linux/bootsect_bin.o syslinux-$(SYSLINUX_VERSION)/linux/ldlinux_bin.o -lc -lc_nonshared glibc/elf/ld.so
+	cp syslinux-$(SYSLINUX_VERSION)/bios/linux/syslinux initrd_dir/bin/syslinux
 
 syslinux_src : syslinux-$(SYSLINUX_VERSION).tar.xz
 	tar xJf syslinux-$(SYSLINUX_VERSION).tar.xz && \
 	cd syslinux-$(SYSLINUX_VERSION) && \
+	make bios && \
 	cd $(CURDIR) && \
 	touch syslinux_src
 

--- a/README
+++ b/README
@@ -28,7 +28,7 @@ with the following packages installed:
 apt-get install nasm gawk zip mkisofs libmpfr-dev libgmp3-dev libmpc-dev \
                 libc6-dev-i386 lib32gcc1 gcc-multilib g++-multilib git-core \
                 qemu cmake libcap-dev mingw32 xz-utils ncurses-dev gettext \
-                autoconf libtool texinfo
+                autoconf libtool texinfo uuid-dev
 
 This software downloads the folding client and cores from Stanford to comply
 with the Folding@Home license.

--- a/initrd_dir/etc/folding/cgi-bin/fold.iso
+++ b/initrd_dir/etc/folding/cgi-bin/fold.iso
@@ -37,7 +37,7 @@ done
 POST_STRING=`echo $POST_STRING | sed 's/&/ /g'`
 dir=/tmp/cd_`date +%s`_$REMOTE_ADDR
 mkdir -p $dir/cd/isolinux
-cp kernel isolinux.bin fold.txt $dir/cd/isolinux
+cp kernel isolinux.bin fold.txt ldlinux.c32 $dir/cd/isolinux
 if [ -f initrd ]
 then
   cp initrd $dir/cd/isolinux


### PR DESCRIPTION
Syslinux v6.02 is faster when loading kernel and initrd, and came with other feature, capability and bug fixes, and also changed to use xz instead of bz2 for tarball to save the bandwidth and disk space, hope can be merged, thanks.
