### PR TITLE
Revert "XZ utils is required by tar"

### DIFF
--- a/README
+++ b/README
@@ -27,7 +27,7 @@ In order to build, you will need an up to date installation of Ubuntu 14.04 (LTS
 with the following additional packages installed:
 apt-get install nasm zip genisoimage libmpfr-dev libgmp3-dev libmpc-dev \
                 libc6-dev-i386 lib32gcc1 gcc-multilib g++-multilib git-core \
-                qemu cmake libcap-dev mingw32 xz-util libncurses5-dev gettext \
+                qemu cmake libcap-dev mingw32 libncurses5-dev gettext \
                 autoconf libtool texinfo uuid-dev
 
 This software downloads the folding client and cores from Stanford to comply


### PR DESCRIPTION
This reverts commit ce265a569c5e8d32de3b8ea78aa16abf68a962c7.

xz-util should be xz-utils here, and according to this list, http://releases.ubuntu.com/releases/trusty/ubuntu-14.04-desktop-amd64.manifest, it's already in it, since we bumped the ubuntu version, we don't need to install it by ourselves anymore.
